### PR TITLE
added possibility to add a Javascript listener directly to the webview

### DIFF
--- a/geotabdrivesdk/src/main/java/com/geotab/mobile/sdk/publicInterfaces/DriveSdk.kt
+++ b/geotabdrivesdk/src/main/java/com/geotab/mobile/sdk/publicInterfaces/DriveSdk.kt
@@ -135,4 +135,17 @@ interface DriveSdk {
      *  - DeviceEvent is the Json string of the device event object.
      */
     fun getDeviceEvents(callback: (Result<Success<String>, Failure>) -> Unit)
+
+    /**
+     * Add a JavaScript interface on the webView
+     * @param listener the class that wil receive the callbacks
+     * @param name JsInterface name, needs to be aligned with the web implementation
+     */
+    fun addJavascriptInterface(listener: Any, name: String)
+
+    /**
+     * Removes a JavaScript interface for a given name
+     * @param name JsInterface name
+     */
+    fun removeJavascriptInterface(name: String)
 }


### PR DESCRIPTION
because of the lifecycle of the fragment, the jsListener can be added in two ways:
1. directly on the webview if it is created
2. first on a list, then set on the webview, as the webview is not created yet